### PR TITLE
fix: Windows download links → v1.2.3 + layout fix

### DIFF
--- a/index.css
+++ b/index.css
@@ -472,7 +472,7 @@ details[open] .faq__q::after {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 32px;
-  max-width: 900px;
+  max-width: 800px;
   margin: 0 auto;
 }
 .download__platform {
@@ -495,7 +495,7 @@ details[open] .faq__q::after {
   gap: 8px;
 }
 .download__badge {
-  height: 44px; width: auto;
+  height: 44px; width: auto; max-width: 100%;
   border-radius: var(--radius-sm);
   transition: transform 0.3s ease, filter 0.3s ease;
   filter: brightness(0.9);
@@ -669,7 +669,7 @@ details[open] .faq__q::after {
   .features__highlights { grid-template-columns: 1fr; }
   .tc { width: 280px; }
   .footer__top { grid-template-columns: 1fr 1fr; gap: 32px; }
-  .download__platforms { grid-template-columns: repeat(2, 1fr); gap: 24px; }
+  .download__platforms { grid-template-columns: repeat(2, 1fr); gap: 24px; max-width: 480px; }
   .download__badge { height: 40px; }
   .steps__grid { flex-direction: column; align-items: center; }
   .step__arrow { transform: rotate(90deg); }
@@ -684,7 +684,7 @@ details[open] .faq__q::after {
   .hero__image { max-width: 260px; }
   .hide-mobile { display: none; }
   .tc { width: 260px; padding: 20px; }
-  .download__platforms { grid-template-columns: 1fr 1fr; gap: 20px; }
+  .download__platforms { grid-template-columns: repeat(2, 1fr); gap: 20px; max-width: 400px; }
   .download__badge { height: 38px; }
   .footer__top { grid-template-columns: 1fr; gap: 28px; text-align: center; }
   .footer__col { align-items: center; }

--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
         "https://play.google.com/store/apps/details?id=tech.gentleflow.airclap.pro",
         "https://www.microsoft.com/store/productId/9N19C4QDKR6D",
         "https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-macos.dmg",
-        "https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-windows.exe",
-        "https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-windows.zip"
+        "https://github.com/Gentleflow/Airclap/releases/download/v1.2.3/Airclap-windows.exe",
+        "https://github.com/Gentleflow/Airclap/releases/download/v1.2.3/Airclap-windows.zip"
       ],
       "screenshot": "https://telegraph-image-b0a.pages.dev/file/fcf8b2939ca97ab1c03f5.jpg",
       "featureList": [
@@ -565,10 +565,10 @@
         <div class="download__platform">
           <h3 class="download__platform-name">Windows</h3>
           <div class="download__platform-badges">
-            <a href="https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-windows.exe" target="_blank" rel="noreferrer noopener">
+            <a href="https://github.com/Gentleflow/Airclap/releases/download/v1.2.3/Airclap-windows.exe" target="_blank" rel="noreferrer noopener">
               <img src="public/badge-exe.webp" alt="Download EXE for Windows" class="download__badge" width="398" height="120">
             </a>
-            <a href="https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-windows.zip" target="_blank" rel="noreferrer noopener">
+            <a href="https://github.com/Gentleflow/Airclap/releases/download/v1.2.3/Airclap-windows.zip" target="_blank" rel="noreferrer noopener">
               <img src="public/badge-zip.webp" alt="Download ZIP for Windows" class="download__badge" width="398" height="120">
             </a>
             <a href="https://www.microsoft.com/store/productId/9N19C4QDKR6D" target="_blank" rel="noreferrer noopener">


### PR DESCRIPTION
## Summary
- Windows EXE/ZIP download links pointed to `releases/latest/download` which resolves to v2.2.0 — a release with no Windows assets (404). Pinned to v1.2.3, the latest release containing Windows builds.
- Schema `downloadUrl` updated accordingly.
- Added `max-width: 100%` to download badges and tightened grid constraints to prevent layout overflow on narrower viewports.

## Test plan
- [ ] Verify Windows EXE link downloads correctly from v1.2.3
- [ ] Verify Windows ZIP link downloads correctly from v1.2.3
- [ ] Check download section layout on desktop (>900px), tablet (600-900px), and mobile (<600px)
- [ ] Validate Schema markup with Google Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)