### PR TITLE
fix: point Windows download links to v1.2.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
         "https://play.google.com/store/apps/details?id=tech.gentleflow.airclap.pro",
         "https://www.microsoft.com/store/productId/9N19C4QDKR6D",
         "https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-macos.dmg",
-        "https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-windows.exe",
-        "https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-windows.zip"
+        "https://github.com/Gentleflow/Airclap/releases/download/v1.2.3/Airclap-windows.exe",
+        "https://github.com/Gentleflow/Airclap/releases/download/v1.2.3/Airclap-windows.zip"
       ],
       "screenshot": "https://telegraph-image-b0a.pages.dev/file/fcf8b2939ca97ab1c03f5.jpg",
       "featureList": [
@@ -565,10 +565,10 @@
         <div class="download__platform">
           <h3 class="download__platform-name">Windows</h3>
           <div class="download__platform-badges">
-            <a href="https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-windows.exe" target="_blank" rel="noreferrer noopener">
+            <a href="https://github.com/Gentleflow/Airclap/releases/download/v1.2.3/Airclap-windows.exe" target="_blank" rel="noreferrer noopener">
               <img src="public/badge-exe.webp" alt="Download EXE for Windows" class="download__badge" width="398" height="120">
             </a>
-            <a href="https://github.com/Gentleflow/Airclap/releases/latest/download/Airclap-windows.zip" target="_blank" rel="noreferrer noopener">
+            <a href="https://github.com/Gentleflow/Airclap/releases/download/v1.2.3/Airclap-windows.zip" target="_blank" rel="noreferrer noopener">
               <img src="public/badge-zip.webp" alt="Download ZIP for Windows" class="download__badge" width="398" height="120">
             </a>
             <a href="https://www.microsoft.com/store/productId/9N19C4QDKR6D" target="_blank" rel="noreferrer noopener">


### PR DESCRIPTION
## Summary
- Windows download links (EXE and ZIP) were returning 404 because the latest release (v2.2.0) has no Windows assets
- Changed Windows links from `/releases/latest/download/` to `/releases/download/v1.2.3/` — the most recent release that includes Windows packages
- macOS DMG link remains on `latest` (working correctly)

## Verified
- `Airclap-windows.exe` (v1.2.3) → 200 OK
- `Airclap-windows.zip` (v1.2.3) → 200 OK
- `Airclap-macos.dmg` (latest) → 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)